### PR TITLE
Add de-dotting support for ES 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This table shows all configuration parameters:
 | Docker host, will add a docker.host=\<host\> field to the event, allowing you to add the hostname of your host, identifying where your container was running (think mesos) | none | REDIS\_DOCKER\_HOST | docker_host |
 | Use Layout v0, what Logstash json format is used. With v0 JSON input support is disabled. | false (meaning we use v1) | REDIS\_USE\_V0\_LAYOUT | use_v0_layout |
 | Logstash type, if set the event will get a @type property | none | REDIS\_LOGSTASH\_TYPE | logstash_type |
+| If true, will replace all "." in container labels with "_". You need to set this if you are using Elasticsearch 2.x | false | DEDOT_LABELS | dedot_labels |
 | Mute errors (to avoid error storm), disable by setting to other than 'true' | true | MUTE\_ERRORS | mute_errors |
 | Redis connection timeout | 100 ms | CONNECT\_TIMEOUT | connect_timeout |
 | Redis read timeout | 300 ms | READ\_TIMEOUT | read_timeout |

--- a/redis.go
+++ b/redis.go
@@ -94,7 +94,7 @@ func NewRedisAdapter(route *router.Route) (router.LogAdapter, error) {
 	docker_host := getopt(route.Options, "docker_host", "REDIS_DOCKER_HOST", "")
 	use_v0 := getopt(route.Options, "use_v0_layout", "REDIS_USE_V0_LAYOUT", "") != ""
 	logstash_type := getopt(route.Options, "logstash_type", "REDIS_LOGSTASH_TYPE", "")
-	dedot_labels := getopt(route.Options, "dedot_labels", "DEDOT_LABELS", "false") == "false"
+	dedot_labels := getopt(route.Options, "dedot_labels", "DEDOT_LABELS", "false") != ""
 	debug := getopt(route.Options, "debug", "DEBUG", "") != ""
 	mute_errors := getopt(route.Options, "mute_errors", "MUTE_ERRORS", "true") == "true"
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -342,6 +342,114 @@ func TestCreateLogstashMessageWithInvalidJsonData(t *testing.T) {
 
 }
 
+func TestCreateLogstashMessageV0WithDeDottingEnabled(t *testing.T) {
+
+	assert := assert.New(t)
+
+	m := router.Message{
+		Container: &docker.Container{
+			ID:   "f00ffd9428dc",
+			Name: "/my_db",
+			Config: &docker.Config{
+				Hostname: "container_hostname",
+				Image:    "my.registry.host:443/path/to/image:4321",
+				Labels:   map[string]string{"label.1.2.3": "abc", "label.3.2.1": "def"},
+			},
+		},
+		Source: "stderr",
+		Data:   "cruel world",
+		Time:   time.Unix(int64(1453813310), 1000000),
+	}
+
+	msg, _ := createLogstashMessage(&m, "tst-mesos-slave-001", true, "some-type", true)
+	jq := makeQuery(msg)
+
+	assert.Equal("abc", getString(jq, "@fields", "docker", "labels", "label_1_2_3"))
+	assert.Equal("def", getString(jq, "@fields", "docker", "labels", "label_3_2_1"))
+
+}
+
+func TestCreateLogstashMessageV1WithDeDottingEnabled(t *testing.T) {
+
+	assert := assert.New(t)
+
+	m := router.Message{
+		Container: &docker.Container{
+			ID:   "f00ffd9428dc",
+			Name: "/my_db",
+			Config: &docker.Config{
+				Hostname: "container_hostname",
+				Image:    "my.registry.host:443/path/to/image:4321",
+				Labels:   map[string]string{"label.1.2.3": "abc", "label.3.2.1": "def"},
+			},
+		},
+		Source: "stderr",
+		Data:   "cruel world",
+		Time:   time.Unix(int64(1453813310), 1000000),
+	}
+
+	msg, _ := createLogstashMessage(&m, "tst-mesos-slave-001", false, "some-type", true)
+	jq := makeQuery(msg)
+
+	assert.Equal("abc", getString(jq, "@fields", "docker", "labels", "label_1_2_3"))
+	assert.Equal("def", getString(jq, "@fields", "docker", "labels", "label_3_2_1"))
+
+}
+
+func TestCreateLogstashMessageV0WithDeDottingDefaultDisabled(t *testing.T) {
+
+	assert := assert.New(t)
+
+	m := router.Message{
+		Container: &docker.Container{
+			ID:   "f00ffd9428dc",
+			Name: "/my_db",
+			Config: &docker.Config{
+				Hostname: "container_hostname",
+				Image:    "my.registry.host:443/path/to/image:4321",
+				Labels:   map[string]string{"label.1.2.3": "abc", "label.3.2.1": "def"},
+			},
+		},
+		Source: "stderr",
+		Data:   "cruel world",
+		Time:   time.Unix(int64(1453813310), 1000000),
+	}
+
+	msg, _ := createLogstashMessage(&m, "tst-mesos-slave-001", true, "some-type")
+	jq := makeQuery(msg)
+
+	assert.Equal("abc", getString(jq, "@fields", "docker", "labels", "label.1.2.3"))
+	assert.Equal("def", getString(jq, "@fields", "docker", "labels", "label.3.2.1"))
+
+}
+
+func TestCreateLogstashMessageV1WithDeDottingDefaultDisabled(t *testing.T) {
+
+	assert := assert.New(t)
+
+	m := router.Message{
+		Container: &docker.Container{
+			ID:   "f00ffd9428dc",
+			Name: "/my_db",
+			Config: &docker.Config{
+				Hostname: "container_hostname",
+				Image:    "my.registry.host:443/path/to/image:4321",
+				Labels:   map[string]string{"label.1.2.3": "abc", "label.3.2.1": "def"},
+			},
+		},
+		Source: "stderr",
+		Data:   "cruel world",
+		Time:   time.Unix(int64(1453813310), 1000000),
+	}
+
+	msg, _ := createLogstashMessage(&m, "tst-mesos-slave-001", false, "some-type")
+	jq := makeQuery(msg)
+
+	assert.Equal("abc", getString(jq, "@fields", "docker", "labels", "label.1.2.3"))
+	assert.Equal("def", getString(jq, "@fields", "docker", "labels", "label.3.2.1"))
+
+}
+
 func TestValidJsonMessageNoJson(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Fixes #11:
- adds dedot_labels parameter
- replaces all Docker labels "." with "_" 
